### PR TITLE
fix: subinvoke rethrow now correctly panics in lib.rs

### DIFF
--- a/cases/subinvoke/02-consumer/implementations/rs/lib.rs
+++ b/cases/subinvoke/02-consumer/implementations/rs/lib.rs
@@ -27,7 +27,7 @@ impl ModuleTrait for Module {
             &imported::imported_invoke_module::ArgsInvokeThrowError { a: args.a },
         );
         if let Err(err) = result {
-            return Err(err.to_string());
+            panic!("{}", err);
         }
         result
     }


### PR DESCRIPTION
the behavior now matches the description in https://github.com/polywrap/toolchain/issues/1639